### PR TITLE
Update parse.py

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -66,7 +66,7 @@ def build_index(directories: str) -> None:
             if not check_for_duplicates(page_text): #check if page is a duplicate
                 count += 1 #increment total files indexed
                 file_count += 1 #increment file count
-                tokens.extend([token.lower() for token in tokenize(page_text)]) #get tokens
+                tokens.extend([str(token).lower() for token in tokenize(page_text)]) #get tokens
                 counter = Counter(tokens)  # for counting frequencies
                 tokens = list(OrderedDict.fromkeys(tokens))  # remove duplicates
                 ID += 1


### PR DESCRIPTION
minor bug fix: ensure 'token' on line 69 is str object. Before this change, this error encountered: " AttributeError: 'int' object has no attribute 'lower' "